### PR TITLE
fix: correct setup-mattpocock-skills → setup-matt-pocock-skills typo

### DIFF
--- a/src/client/statusbar/checksums.js
+++ b/src/client/statusbar/checksums.js
@@ -16,7 +16,7 @@ export const checksumsOf = function (s) {
   const amber = s.checksMode === 'real' && setup && setup.level !== 'ok'
   // v1.5 T11 + #229：核心技能检测 = 三个通用技能行的最差者（legacy 回退视图保留 id 9 聚合行兼容）
   const _suiteRow = (s.checks || []).find(function (c) { return c.id === 9 })
-  const _skillRows9 = ['skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(s.checks, k) }).filter(Boolean)
+  const _skillRows9 = ['skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(s.checks, k) }).filter(Boolean)
   const skillsCheck = (_skillRows9.find(function (r) { return r.level !== 'ok' })) || _suiteRow || _skillRows9[0] || null
   const skillsBad = s.checksMode === 'real' && skillsCheck && skillsCheck.level !== 'ok'
   // v1.5 引导依赖链（用户拍板 2026-08-17）：gh CLI → gh 登录 → setup → 技能 —— banner 显示依赖链上第一个缺失项（#229 行不存在则该环节跳过）

--- a/src/client/views/ChecksTab.js
+++ b/src/client/views/ChecksTab.js
@@ -52,7 +52,7 @@ export     const ChecksTab = ({ st }) => {
       const cs0 = activeChecks(st)
       const ghCli2 = findCheck(cs0, 'gh:installed')
       const ghAuth2 = findCheck(cs0, 'gh:authed')
-      const _skillRowsChk = ['skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(cs0, k) }).filter(Boolean)
+      const _skillRowsChk = ['skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(cs0, k) }).filter(Boolean)
       const _suiteRowChk = cs0.find(function (c) { return c.id === 9 })
       const skillsCheck2 = (_skillRowsChk.find(function (r) { return r.level !== 'ok' })) || _suiteRowChk || _skillRowsChk[0] || null
       const setupCheck2 = findCheck(cs0, 'tracker:initialized')

--- a/src/host/tracker/statusDerive.js
+++ b/src/host/tracker/statusDerive.js
@@ -35,7 +35,7 @@ export const ROW_NAMES = Object.freeze({
   'selection:backendSelected': { zh: '已选择后端', en: 'Backend selected' },
   'tracker:initialized': { zh: '工作区已初始化', en: 'Workspace initialized' },
   'skill:wayfinder': { zh: 'wayfinder 技能已安装', en: 'wayfinder skill installed' },
-  'skill:setup-mattpocock-skills': { zh: 'setup-mattpocock-skills 技能已安装', en: 'setup-mattpocock-skills skill installed' },
+  'skill:setup-matt-pocock-skills': { zh: 'setup-matt-pocock-skills 技能已安装', en: 'setup-matt-pocock-skills skill installed' },
   'skill:ask-matt': { zh: 'ask-matt 技能已安装', en: 'ask-matt skill installed' },
   'env:home': { zh: '用户主目录可解析', en: 'User home resolvable' },
   'gh:remote': { zh: '仓库定位', en: 'Repo located' },
@@ -61,7 +61,7 @@ export const LEGACY_ID = Object.freeze({
 })
 
 /** 展示顺序：开门组 → 通用环境组 → 后端分区（目录内稳定排序）。 */
-export const GENERIC_ORDER = Object.freeze(['selection:backendSelected', 'tracker:initialized', 'skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt', 'env:home'])
+export const GENERIC_ORDER = Object.freeze(['selection:backendSelected', 'tracker:initialized', 'skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt', 'env:home'])
 
 function nameFor(key, lang) {
   const t = ROW_NAMES[key]
@@ -253,7 +253,7 @@ export async function deriveStatusView(deps) {
   rows.push(initRow)
 
   // —— 通用 · 环境组（技能 ×3 + HOME）——
-  const SKILL_KEYS = ['skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt']
+  const SKILL_KEYS = ['skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt']
   for (const key of SKILL_KEYS) {
     const row = baseRow(key, lang)
     const skillName = key.slice('skill:'.length)

--- a/src/shared/tracker/check-catalog.js
+++ b/src/shared/tracker/check-catalog.js
@@ -38,11 +38,11 @@ export const GENERIC_CATALOG = Object.freeze([
     origin: 'host/index.js:SKILL_PROBE_NAMES (inventory 类别 8)',
   },
   {
-    id: 'skill:setup-mattpocock-skills',
-    label: '技能 setup-mattpocock-skills 已安装',
+    id: 'skill:setup-matt-pocock-skills',
+    label: '技能 setup-matt-pocock-skills 已安装',
     scope: 'generic',
     backends: ['github','markdown','gitlab'],
-    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-mattpocock-skills' },
+    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-matt-pocock-skills' },
     origin: 'host/index.js:SKILL_PROBE_NAMES',
   },
   {
@@ -202,7 +202,7 @@ export function catalogFor(backendId) {
  */
 export const MIGRATION_MAP = Object.freeze({
   'skill:wayfinder': 'GENERIC_CATALOG[0]',
-  'skill:setup-mattpocock-skills': 'GENERIC_CATALOG[1]',
+  'skill:setup-matt-pocock-skills': 'GENERIC_CATALOG[1]',
   'skill:ask-matt': 'GENERIC_CATALOG[2]',
   'env:home': 'GENERIC_CATALOG[3]',
   'tracker:initialized': 'GENERIC_CATALOG[4]',
@@ -245,11 +245,11 @@ export const GENERIC_CHECK_ITEMS = Object.freeze([
     group: 'env',
   },
   {
-    id: 'skill:setup-mattpocock-skills',
-    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-mattpocock-skills' },
-    onPass: { show: { i18nKey: 'check.skill.setup-mattpocock-skills.pass', fallback: '技能 setup-mattpocock-skills 已安装', level: 'info' }, actions: [] },
-    onFail: { show: { i18nKey: 'check.skill.setup-mattpocock-skills.fail', fallback: '技能 setup-mattpocock-skills 未安装', level: 'bad', hint: 'prompt:installSkills' }, actions: [{ type: ACTION_TYPE.INJECT_PROMPT, prompt: 'installSkills' }] },
-    label: '技能 setup-mattpocock-skills 已安装',
+    id: 'skill:setup-matt-pocock-skills',
+    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-matt-pocock-skills' },
+    onPass: { show: { i18nKey: 'check.skill.setup-matt-pocock-skills.pass', fallback: '技能 setup-matt-pocock-skills 已安装', level: 'info' }, actions: [] },
+    onFail: { show: { i18nKey: 'check.skill.setup-matt-pocock-skills.fail', fallback: '技能 setup-matt-pocock-skills 未安装', level: 'bad', hint: 'prompt:installSkills' }, actions: [{ type: ACTION_TYPE.INJECT_PROMPT, prompt: 'installSkills' }] },
+    label: '技能 setup-matt-pocock-skills 已安装',
     group: 'env',
   },
   {


### PR DESCRIPTION
## Summary

The `SKILL_KEYS` array in `statusDerive.js` used `setup-mattpocock-skills` (missing hyphen between matt and pocock), causing `probeSkill` to look for a non-existent directory. This made the `setup-matt-pocock-skills` skill row always report "not installed" in the status panel, while the other 9 skills worked fine.

The same typo was present in:
- `check-catalog.js`: id, label, skill, i18nKey fields
- `client/statusbar/checksums.js`: skill row lookup key
- `client/views/ChecksTab.js`: skill row lookup key

The correct name matches:
- The upstream `mattpocock/skills` repo directory name
- The plugin's own `SKILL_PROBE_NAMES` array in `host/index.js`

## Root cause

`deriveStatusView` strips the `skill:` prefix from the key to get the skill name, then passes it to `probeSkill`. With the wrong name, `probeSkill` probes `~/.agents/skills/setup-mattpocock-skills/` which doesn't exist (the actual directory is `setup-matt-pocock-skills/`).

## Changes

4 files, 14 occurrences of `setup-mattpocock-skills` → `setup-matt-pocock-skills`

| File | Lines |
|------|-------|
| `src/host/tracker/statusDerive.js` | 3 (ROW_NAMES, GENERIC_ORDER, SKILL_KEYS) |
| `src/shared/tracker/check-catalog.js` | 9 (id, label, skill, i18nKey, MIGRATION_MAP) |
| `src/client/statusbar/checksums.js` | 1 (_skillRows9) |
| `src/client/views/ChecksTab.js` | 1 (_skillRowsChk) |