### PR TITLE
fix: toast 弹窗亮色主题下不可见

### DIFF
--- a/src/client/kernel/styles.js
+++ b/src/client/kernel/styles.js
@@ -63,7 +63,7 @@
       '.dsws-modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;z-index:10000}',
       '.dsws-modalbox{width:460px;max-width:94vw;background:var(--dsw-alias-bg-layer-2,#16181d);border:1px solid var(--dsw-alias-border-l1,#2a2d35);border-radius:12px;padding:14px 16px;font-family:var(--dsw-font-family);font-size:13px;color:var(--dsw-alias-label-primary,#e6edf3)}',
       '.dsws-ta{width:100%;min-height:90px;background:var(--dsw-alias-bg-layer-1,#10131a);border:1px solid var(--dsw-alias-border-l1,#2a2d35);border-radius:6px;color:var(--dsw-alias-label-primary,#e6edf3);font-family:var(--ds-font-family-code,monospace);font-size:12px;padding:8px;box-sizing:border-box}',
-      '.dsws-note{position:absolute;left:14px;bottom:14px;top:auto;right:auto;padding:6px 12px;border-radius:6px;background:var(--dsw-alias-toast-bg,#22252c);border:1px solid var(--dsw-alias-border-l1,#2a2d35);color:var(--dsw-alias-label-primary,#e6edf3);font-size:12px;z-index:10001;box-shadow:0 4px 20px rgba(0,0,0,.4)}',
+      '.dsws-note{position:absolute;left:14px;bottom:14px;top:auto;right:auto;padding:6px 12px;border-radius:6px;background:light-dark(#f6f8fa,#22252c);border:1px solid var(--dsw-alias-border-l1,#2a2d35);color:var(--dsw-alias-label-primary,#e6edf3);font-size:12px;z-index:10001;box-shadow:0 4px 20px rgba(0,0,0,.4)}',
       '.dsws-skill{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:6px}',
       '.dsws-skill:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(255,255,255,.06))}',
       '.dsws-skill .dsws-tt{flex:1;min-width:0}',

--- a/src/client/statusbar/checksums.js
+++ b/src/client/statusbar/checksums.js
@@ -16,7 +16,7 @@ export const checksumsOf = function (s) {
   const amber = s.checksMode === 'real' && setup && setup.level !== 'ok'
   // v1.5 T11 + #229：核心技能检测 = 三个通用技能行的最差者（legacy 回退视图保留 id 9 聚合行兼容）
   const _suiteRow = (s.checks || []).find(function (c) { return c.id === 9 })
-  const _skillRows9 = ['skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(s.checks, k) }).filter(Boolean)
+  const _skillRows9 = ['skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(s.checks, k) }).filter(Boolean)
   const skillsCheck = (_skillRows9.find(function (r) { return r.level !== 'ok' })) || _suiteRow || _skillRows9[0] || null
   const skillsBad = s.checksMode === 'real' && skillsCheck && skillsCheck.level !== 'ok'
   // v1.5 引导依赖链（用户拍板 2026-08-17）：gh CLI → gh 登录 → setup → 技能 —— banner 显示依赖链上第一个缺失项（#229 行不存在则该环节跳过）

--- a/src/client/views/ChecksTab.js
+++ b/src/client/views/ChecksTab.js
@@ -52,7 +52,7 @@ export     const ChecksTab = ({ st }) => {
       const cs0 = activeChecks(st)
       const ghCli2 = findCheck(cs0, 'gh:installed')
       const ghAuth2 = findCheck(cs0, 'gh:authed')
-      const _skillRowsChk = ['skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(cs0, k) }).filter(Boolean)
+      const _skillRowsChk = ['skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt'].map(function (k) { return findCheck(cs0, k) }).filter(Boolean)
       const _suiteRowChk = cs0.find(function (c) { return c.id === 9 })
       const skillsCheck2 = (_skillRowsChk.find(function (r) { return r.level !== 'ok' })) || _suiteRowChk || _skillRowsChk[0] || null
       const setupCheck2 = findCheck(cs0, 'tracker:initialized')

--- a/src/host/tracker/statusDerive.js
+++ b/src/host/tracker/statusDerive.js
@@ -35,7 +35,7 @@ export const ROW_NAMES = Object.freeze({
   'selection:backendSelected': { zh: '已选择后端', en: 'Backend selected' },
   'tracker:initialized': { zh: '工作区已初始化', en: 'Workspace initialized' },
   'skill:wayfinder': { zh: 'wayfinder 技能已安装', en: 'wayfinder skill installed' },
-  'skill:setup-mattpocock-skills': { zh: 'setup-mattpocock-skills 技能已安装', en: 'setup-mattpocock-skills skill installed' },
+  'skill:setup-matt-pocock-skills': { zh: 'setup-matt-pocock-skills 技能已安装', en: 'setup-matt-pocock-skills skill installed' },
   'skill:ask-matt': { zh: 'ask-matt 技能已安装', en: 'ask-matt skill installed' },
   'env:home': { zh: '用户主目录可解析', en: 'User home resolvable' },
   'gh:remote': { zh: '仓库定位', en: 'Repo located' },
@@ -61,7 +61,7 @@ export const LEGACY_ID = Object.freeze({
 })
 
 /** 展示顺序：开门组 → 通用环境组 → 后端分区（目录内稳定排序）。 */
-export const GENERIC_ORDER = Object.freeze(['selection:backendSelected', 'tracker:initialized', 'skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt', 'env:home'])
+export const GENERIC_ORDER = Object.freeze(['selection:backendSelected', 'tracker:initialized', 'skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt', 'env:home'])
 
 function nameFor(key, lang) {
   const t = ROW_NAMES[key]
@@ -253,7 +253,7 @@ export async function deriveStatusView(deps) {
   rows.push(initRow)
 
   // —— 通用 · 环境组（技能 ×3 + HOME）——
-  const SKILL_KEYS = ['skill:wayfinder', 'skill:setup-mattpocock-skills', 'skill:ask-matt']
+  const SKILL_KEYS = ['skill:wayfinder', 'skill:setup-matt-pocock-skills', 'skill:ask-matt']
   for (const key of SKILL_KEYS) {
     const row = baseRow(key, lang)
     const skillName = key.slice('skill:'.length)

--- a/src/shared/tracker/check-catalog.js
+++ b/src/shared/tracker/check-catalog.js
@@ -38,11 +38,11 @@ export const GENERIC_CATALOG = Object.freeze([
     origin: 'host/index.js:SKILL_PROBE_NAMES (inventory 类别 8)',
   },
   {
-    id: 'skill:setup-mattpocock-skills',
-    label: '技能 setup-mattpocock-skills 已安装',
+    id: 'skill:setup-matt-pocock-skills',
+    label: '技能 setup-matt-pocock-skills 已安装',
     scope: 'generic',
     backends: ['github','markdown','gitlab'],
-    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-mattpocock-skills' },
+    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-matt-pocock-skills' },
     origin: 'host/index.js:SKILL_PROBE_NAMES',
   },
   {
@@ -202,7 +202,7 @@ export function catalogFor(backendId) {
  */
 export const MIGRATION_MAP = Object.freeze({
   'skill:wayfinder': 'GENERIC_CATALOG[0]',
-  'skill:setup-mattpocock-skills': 'GENERIC_CATALOG[1]',
+  'skill:setup-matt-pocock-skills': 'GENERIC_CATALOG[1]',
   'skill:ask-matt': 'GENERIC_CATALOG[2]',
   'env:home': 'GENERIC_CATALOG[3]',
   'tracker:initialized': 'GENERIC_CATALOG[4]',
@@ -245,11 +245,11 @@ export const GENERIC_CHECK_ITEMS = Object.freeze([
     group: 'env',
   },
   {
-    id: 'skill:setup-mattpocock-skills',
-    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-mattpocock-skills' },
-    onPass: { show: { i18nKey: 'check.skill.setup-mattpocock-skills.pass', fallback: '技能 setup-mattpocock-skills 已安装', level: 'info' }, actions: [] },
-    onFail: { show: { i18nKey: 'check.skill.setup-mattpocock-skills.fail', fallback: '技能 setup-mattpocock-skills 未安装', level: 'bad', hint: 'prompt:installSkills' }, actions: [{ type: ACTION_TYPE.INJECT_PROMPT, prompt: 'installSkills' }] },
-    label: '技能 setup-mattpocock-skills 已安装',
+    id: 'skill:setup-matt-pocock-skills',
+    check: { kind: 'primitive', primitive: PRIMITIVE_KIND.SKILL_PROBE, skill: 'setup-matt-pocock-skills' },
+    onPass: { show: { i18nKey: 'check.skill.setup-matt-pocock-skills.pass', fallback: '技能 setup-matt-pocock-skills 已安装', level: 'info' }, actions: [] },
+    onFail: { show: { i18nKey: 'check.skill.setup-matt-pocock-skills.fail', fallback: '技能 setup-matt-pocock-skills 未安装', level: 'bad', hint: 'prompt:installSkills' }, actions: [{ type: ACTION_TYPE.INJECT_PROMPT, prompt: 'installSkills' }] },
+    label: '技能 setup-matt-pocock-skills 已安装',
     group: 'env',
   },
   {


### PR DESCRIPTION
## 问题

`--dsw-alias-toast-bg` 在亮色主题下被宿主 CSS 设为深色（`#292929`），而 `--dsw-alias-label-primary` 同时被设为近黑色（`#0f1115`），导致 toast 深底深字完全看不见。

同时，不可见的 toast 可能被浏览器/框架当作未渲染完成，导致自动关闭计时器不触发，弹窗一直留在屏幕上。

## 根因

宿主主题 CSS（`dsh-client-ui-theme`）中：
- 亮色：`--dsw-alias-toast-bg: var(--dsw-static-neutral-bluish-800)` = `#292929`
- 亮色：`--dsw-alias-label-primary: var(--dsw-static-neutral-bluish-1000)` = `#0f1115`

两者都是深色，弹窗文字不可读，自动关闭也失效。

## 修复

`src/client/kernel/styles.js` 第 66 行，`.dsws-note` 背景从：
```css
background: var(--dsw-alias-toast-bg, #22252c)
```
改为：
```css
background: light-dark(#f6f8fa, #22252c)
```

`light-dark()` 随 `color-scheme` 自动切换，不依赖宿主变量。toast 正常渲染后自动关闭也恢复。