### PR TITLE
setup-matt-pocock-skills: 完善 triage + wayfinder 标签文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Issues live as GitHub issues, driven through the `gh` CLI. See `docs/agents/issu
 
 ### Triage labels
 
-Five canonical triage roles map to this repo's labels; the mandatory label set is `bug` / `needs-triage` / `wayfinder:grilling`. See `docs/agents/triage-labels.md`.
+Five canonical triage roles (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`) plus five wayfinder labels (`wayfinder:map` / `research` / `prototype` / `grilling` / `task`). See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Issues live as GitHub issues, driven through the `gh` CLI. See `docs/agents/issu
 
 ### Triage labels
 
-Five canonical triage roles (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`) plus five wayfinder labels (`wayfinder:map` / `research` / `prototype` / `grilling` / `task`). See `docs/agents/triage-labels.md`.
+Five canonical triage roles (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`) plus five wayfinder labels (`wayfinder:map` / `research` / `prototype` / `grilling` / `task`). The **mandatory label set** is `bug` / `needs-triage` / `wayfinder:grilling`. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -20,4 +20,14 @@ This repo's deck uses a mandatory label set alongside the triage roles. These th
 - `needs-triage` — unexamined issue awaiting diagnosis (drives the diagnose action / TRIAGE filter; this is also the canonical `needs-triage` role above)
 - `wayfinder:grilling` — an open decision/discussion ticket (drives the discuss action; wayfinder's `grilling` ticket type)
 
+## Wayfinder label set
+
+The `/wayfinder` skill requires all five wayfinder labels to exist. Every wayfinder child ticket carries exactly one of them:
+
+- `wayfinder:map` — the parent map issue (Notes / Decisions-so-far / Fog)
+- `wayfinder:research` — research ticket
+- `wayfinder:prototype` — prototype ticket
+- `wayfinder:grilling` — grilling/discussion ticket
+- `wayfinder:task` — implementation task ticket
+
 Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## 变更
- AGENTS.md: Triage labels 区块更新，完整列出 10 个必需标签（5 triage + 5 wayfinder）
- docs/agents/triage-labels.md: 新增 Wayfinder label set 章节

## 验证
- GitHub 上所有 10 个标签已存在
- verify-setup-describe.js: 77/77 PASS
- verify-tracker-contract.js: 382 PASS