### PR TITLE
fix: unblock CI and Pages root deployment

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,13 +23,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11
           run_install: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install (pnpm)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=architecture/MattSkills-architecture.html"><title>MattSkills</title></head><body><a href="architecture/MattSkills-architecture.html">Open architecture</a></body></html>


### PR DESCRIPTION
Align pnpm action with packageManager and add a Pages root redirect to the architecture documentation.