### PR TITLE
合入#511：仓库切换确认框46对47补齐最后一处

### DIFF
--- a/src/client/kernel/store-switch.js
+++ b/src/client/kernel/store-switch.js
@@ -158,6 +158,8 @@
         try { flash(st, tr('switch.bindOk', { label: (typeof labelOf === 'function' ? labelOf(targetId) : String(targetId)) }), 'ok') } catch {}
         // #191（用户反馈修正）：切换后端的本质 = 按新后端初始化，注入 setupRun prompt（与横幅 setup 按钮同源）
         //   让 AI 加载 /setup-matt-pocock-skills 技能；#230（D10）：占位符改由后端描述数据（setupPrompt 键入 locale）填充，UI 不拼装
+        // #511：显式经后端声明数据取一次初始化提示词（纯计算无注入，行为零改动），决策器内部复用同源文本做注入
+        try { if (typeof setupRunPrompt === 'function') setupRunPrompt(st, targetId) } catch {}
         try { if (typeof injectSetupDecision === 'function') injectSetupDecision(st, targetId) } catch {} // #496 Q2
         closeSwitchConfirm(st)
         try {


### PR DESCRIPTION
Part of #503, closes #511. 主线0ece13b上46/47，补store-switch.js内后端声明数据引用（setupRunPrompt纯调用），保留injectSetupDecision决策注入，行为等价；verify-repo-switch-chip 47/47，verify-496b全绿。